### PR TITLE
update cloak config for oragono 2.1.0

### DIFF
--- a/base/ircd.yaml
+++ b/base/ircd.yaml
@@ -221,17 +221,6 @@ server:
         # fake TLD at the end of the hostname, e.g., pwbs2ui4377257x8.oragono
         netname: "hashbang.sh"
 
-        # secret key to prevent dictionary attacks against cloaked IPs
-        # any high-entropy secret is valid for this purpose:
-        # you MUST generate a new one for your installation.
-        # suggestion: use the output of `oragono mksecret`
-        # note that rotating this key will invalidate all existing ban masks.
-        secret: ""
-
-        # name of an environment variable to pull the secret from, for use with
-        # k8s secret distribution:
-        secret-environment-variable: "ORAGONO_CLOAKING_SECRET"
-
         # the cloaked hostname is derived only from the CIDR (most significant bits
         # of the IP address), up to a configurable number of bits. this is the
         # granularity at which bans will take effect for IPv4. Note that changing
@@ -245,7 +234,7 @@ server:
         # more bits means less likelihood of distinct IPs colliding,
         # at the cost of a longer cloaked hostname. if this value is set to 0,
         # all users will receive simply `netname` as their cloaked hostname.
-        num-bits: 80
+        num-bits: 64
 
 
 # account options

--- a/base/ircd.yaml
+++ b/base/ircd.yaml
@@ -287,6 +287,10 @@ accounts:
     # PASS as well, so it can be configured to authenticate with SASL only.
     skip-server-password: false
 
+    # enable login to accounts via the PASS command, e.g., PASS account:password
+    # this is sometimes useful for compatibility with old clients that don't support SASL
+    login-via-pass-command: true
+
     # require-sasl controls whether clients are required to have accounts
     # (and sign into them using SASL) to connect to the server
     require-sasl:
@@ -320,13 +324,19 @@ accounts:
 
         # allow users to set their own nickname enforcement status, e.g.,
         # to opt in to strict enforcement
-        allow-custom-enforcement: true
+        allow-custom-enforcement: false
 
         # rename-timeout - this is how long users have 'til they're renamed
         rename-timeout: 30s
 
         # rename-prefix - this is the prefix to use when renaming clients (e.g. Guest-AB54U31)
         rename-prefix: Guest-
+
+        # when enabled, forces users logged into an account to use the
+        # account name as their nickname. when combined with strict nickname
+        # enforcement, this lets users treat nicknames and account names
+        # as equivalent for the purpose of ban/invite/exception lists.
+        force-nick-equals-account: true
 
     # bouncer controls whether oragono can act as a bouncer, i.e., allowing
     # multiple connections to attach to the same client/nickname identity
@@ -345,6 +355,9 @@ accounts:
         # when they have no active connections. The possible values are:
         # "disabled", "opt-in", "opt-out", or "mandatory".
         always-on: "opt-in"
+
+        # whether to mark always-on clients away when they have no active connections:
+        auto-away: "opt-in"
 
     # vhosts controls the assignment of vhosts (strings displayed in place of the user's
     # hostname/IP) by the HostServ service
@@ -513,7 +526,7 @@ logging:
         #   internal        unexpected runtime behavior, including potential bugs
         #   userinput       raw lines sent by users
         #   useroutput      raw lines sent to users
-        type: "server listeners localconnect localconnect-ip quit internal"
+        type: "server listeners connect connect-ip quit internal"
 
         # one of: debug info warn error
         level: debug


### PR DESCRIPTION
We just put out the [release candidate for 2.1.0](https://github.com/oragono/oragono/releases/tag/v2.1.0-rc1). In this version, the cloak secret is stored in the database, so (a) there's no concern about exposing it in a config file (b) support for distributing it as an environment variable has been removed.

Upgrading to 2.1.0 will autogenerate a cloak secret and store it in the database.